### PR TITLE
Fix ValueError on 'N/A' channel data

### DIFF
--- a/omada_respondd/respondd_client.py
+++ b/omada_respondd/respondd_client.py
@@ -297,9 +297,9 @@ class ResponddClient:
     def getStatistics(self):
         """This method returns the statistics information of all APs."""
         aps = self._aps
-        statistics = []
+        statistics: List[StatisticsInfo] = []
         for ap in aps.accesspoints:
-            wirelessinfos = []
+            wirelessinfos: List[WirelessInfo] = []
 
             if ap.frequency24:
                 wirelessinfos.append(


### PR DESCRIPTION
We have one AP in the controller which seems to have trouble with the 2,4 GHz radio, where it does not show any channel even though it is enabled. The reported channelData is `N/A`.
This caused the following exception:
```
Traceback (most recent call last):
  File "/opt/omada_respondd/respondd.py", line 14, in <module>
    main()
  File "/opt/omada_respondd/respondd.py", line 10, in main
    extResponddClient.start()
  File "/opt/omada_respondd/omada_respondd/respondd_client.py", line 401, in start
    self._aps = omada_client.get_infos()
  File "/opt/omada_respondd/omada_respondd/omada_client.py", line 208, in get_infos
    
  File "/opt/omada_respondd/omada_respondd/omada_client.py", line 128, in get_ap_frequency
    try:
ValueError: invalid literal for int() with base 10: 'A'
```

## Changes
Now we return `None` in `get_ap_frequency()` if `channelData` is `N/A`, which propagates up and results in just no wifi statistics being listed in the respondd output, see:
https://github.com/freifunkMUC/omada_respondd/blob/c2df615c22e731d5cfb34601f61e4502ceb7b868/omada_respondd/respondd_client.py#L304-L316

If any other errors occur in this function, we now log an error instead of crashing.