### PR TITLE
Fix crash when wp2g key is missing in AP infos

### DIFF
--- a/omada_respondd/omada_client.py
+++ b/omada_respondd/omada_client.py
@@ -295,12 +295,12 @@ def get_infos():
 
                 frequency24 = None
                 wp2g = moreAPInfos.get("wp2g", None)
-                if wp2g.get("actualChannel", None) is not None:
+                if wp2g is not None and wp2g.get("actualChannel", None) is not None:
                     frequency24 = get_ap_frequency(wp2g.get("actualChannel"))
 
                 frequency5 = None
                 wp5g = moreAPInfos.get("wp5g", None)
-                if wp5g.get("actualChannel", None) is not None:
+                if wp5g is not None and wp5g.get("actualChannel", None) is not None:
                     frequency5 = get_ap_frequency(wp5g.get("actualChannel"))
 
                 neighbour_macs = []


### PR DESCRIPTION
Omada_respondd was in a crash loop on gw04 due to the following exception:
```
Traceback (most recent call last):
  File "/opt/omada_respondd/respondd.py", line 14, in <module>
    main()
  File "/opt/omada_respondd/respondd.py", line 10, in main
    extResponddClient.start()
  File "/opt/omada_respondd/omada_respondd/respondd_client.py", line 405, in start
    self._aps = omada_client.get_infos()
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/omada_respondd/omada_respondd/omada_client.py", line 298, in get_infos
    if wp2g.get("actualChannel", None) is not None:
       ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
omada_respondd.service: Main process exited, code=exited, status=1/FAILURE
```

Don't know why some access point doesn't have this info suddenly, but in any case we need to handle it gracefully.
The code now includes a None-check before trying to access any properties of `wp2g`/`wp5g`.